### PR TITLE
Fix bootConfig() publishing a relative source path

### DIFF
--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -69,7 +69,7 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
         }
 
         $this->publishes(
-            [$path => config_path($configFile)],
+            [$this->disk()->path($path) => config_path($configFile)],
             $this->slug().'-config'
         );
 

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -32,7 +32,7 @@ it('publishes config', function () {
     $provider
         ->shouldReceive('publishes')
         ->once()
-        ->with(['config/two-words.php' => config_path('two-words.php')], 'two-words-config');
+        ->with([$disk->path('config/two-words.php') => config_path('two-words.php')], 'two-words-config');
 
     $provider->boot();
 });


### PR DESCRIPTION
publishes() expects absolute paths; using the raw relative disk path caused vendor:publish to resolve the source from CWD rather than the feature root.