### PR TITLE
Replace Storage disk with File::directories()

### DIFF
--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -3,7 +3,6 @@
 namespace Edalzell\Features\Concerns;
 
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Storage;
 use ReflectionClass;
 
 trait HasFeatures
@@ -18,10 +17,8 @@ trait HasFeatures
             return;
         }
 
-        $disk = Storage::build(['driver' => 'local', 'root' => $path]);
-
-        collect($disk->directories())
-            ->filter(fn (string $name) => $disk->exists($name.'/src/ServiceProvider.php'))
-            ->each(fn (string $name) => $this->app->register($namespacePrefix.'\\'.$name.'\\ServiceProvider'));
+        collect(File::directories($path))
+            ->filter(fn (string $dir) => File::exists($dir.'/src/ServiceProvider.php'))
+            ->each(fn (string $dir) => $this->app->register($namespacePrefix.'\\'.basename($dir).'\\ServiceProvider'));
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,9 +4,9 @@ use Edalzell\Features\ServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
 
 it('registers feature', function () {
-    $featuresDisk = tap(mockOnDemandDisk('features'))->put('TwoWords/src/ServiceProvider.php', '');
-
     File::expects('exists')->with(base_path('features'))->andReturns(true);
+    File::expects('directories')->with(base_path('features'))->andReturns([base_path('features/TwoWords')]);
+    File::expects('exists')->with(base_path('features/TwoWords').'/src/ServiceProvider.php')->andReturns(true);
 
     $app = mock(Application::class);
 
@@ -20,9 +20,9 @@ it('registers feature', function () {
 });
 
 it('doesnt register feature when no provider', function () {
-    $featuresDisk = tap(mockOnDemandDisk('features'))->put('TwoWords/src/Foo.php', '');
-
     File::expects('exists')->with(base_path('features'))->andReturns(true);
+    File::expects('directories')->with(base_path('features'))->andReturns([base_path('features/TwoWords')]);
+    File::expects('exists')->with(base_path('features/TwoWords').'/src/ServiceProvider.php')->andReturns(false);
 
     $app = mock(Application::class);
 


### PR DESCRIPTION
Building a full Flysystem disk adapter just to list directories was unnecessary overhead. File::directories() returns absolute paths directly, making the filter and registration logic simpler.