### PR TITLE
Simplify namespace() by removing no-op

### DIFF
--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -118,7 +118,7 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
 
     protected function namespace(): string
     {
-        return str($this->reflection->getNamespaceName())->replaceEnd('\ServiceProvider', '');
+        return $this->reflection->getNamespaceName();
     }
 
     protected function registerConfig(): self


### PR DESCRIPTION
getNamespaceName() already returns only the namespace without the class name, so replaceEnd('\ServiceProvider', '') was always a no-op.