### PR TITLE
Fix local feature namespace when used inside a package

### DIFF
--- a/src/Composer/FeatureNamespaces.php
+++ b/src/Composer/FeatureNamespaces.php
@@ -103,6 +103,15 @@ class FeatureNamespaces
     private function featuresNamespace(array $featurePaths = []): string
     {
         if (empty($featurePaths)) {
+            // When the root package has its own PSR-4 namespace (i.e. it's a package,
+            // not a Laravel app), prefix Features with that namespace so local feature
+            // classes resolve correctly during package development.
+            $rootPsr4 = array_key_first($this->autoload['psr-4'] ?? []);
+
+            if ($rootPsr4 && $rootPsr4 !== 'App\\') {
+                return rtrim($rootPsr4, '\\').'\\Features';
+            }
+
             return 'Features';
         }
 

--- a/tests/Isolated/Composer/FeatureNamespacesTest.php
+++ b/tests/Isolated/Composer/FeatureNamespacesTest.php
@@ -77,6 +77,52 @@ it('throws when the package composer.json is missing psr-4 autoload', function (
     FeatureNamespaces::add(new Event('pre-autoload-dump', $composer, new NullIO));
 })->throws(Exception::class, 'missing autoload.psr-4');
 
+it('uses package namespace for local features when root is not an app', function () {
+    $package = new RootPackage('myvendor/my-package', '1.0', 'v1.0');
+    $package->setAutoload(['psr-4' => ['MyVendor\\MyPackage\\' => 'src/']]);
+    $composer = tap(new Composer)->setPackage($package);
+    $featuresDir = getcwd().'/features';
+
+    when('is_dir')->justReturn(true);
+    Functions\expect('glob')->once()->with($featuresDir.'/*')->andReturn([$featuresDir.'/One'])
+        ->andAlsoExpectIt()->once()->with(getcwd().'/vendor/*/*/features/*')->andReturn([]);
+
+    FeatureNamespaces::add(new Event('pre-autoload-dump', $composer, new NullIO));
+
+    expect($package)
+        ->getAutoload()->toBe(['psr-4' => [
+            'MyVendor\\MyPackage\\' => 'src/',
+            'MyVendor\\MyPackage\\Features\\One\\' => 'features/One/src',
+            'MyVendor\\MyPackage\\Features\\One\\Database\\Factories\\' => 'features/One/database/factories',
+            'MyVendor\\MyPackage\\Features\\One\\Database\\Seeders\\' => 'features/One/database/seeders',
+        ]])->getDevAutoload()->toBe(['psr-4' => [
+            'MyVendor\\MyPackage\\Features\\One\\Tests\\' => 'features/One/tests',
+        ]]);
+});
+
+it('uses plain Features namespace for local features when root is a Laravel app', function () {
+    $package = new RootPackage('myapp/app', '1.0', 'v1.0');
+    $package->setAutoload(['psr-4' => ['App\\' => 'app/']]);
+    $composer = tap(new Composer)->setPackage($package);
+    $featuresDir = getcwd().'/features';
+
+    when('is_dir')->justReturn(true);
+    Functions\expect('glob')->once()->with($featuresDir.'/*')->andReturn([$featuresDir.'/One'])
+        ->andAlsoExpectIt()->once()->with(getcwd().'/vendor/*/*/features/*')->andReturn([]);
+
+    FeatureNamespaces::add(new Event('pre-autoload-dump', $composer, new NullIO));
+
+    expect($package)
+        ->getAutoload()->toBe(['psr-4' => [
+            'App\\' => 'app/',
+            'Features\\One\\' => 'features/One/src',
+            'Features\\One\\Database\\Factories\\' => 'features/One/database/factories',
+            'Features\\One\\Database\\Seeders\\' => 'features/One/database/seeders',
+        ]])->getDevAutoload()->toBe(['psr-4' => [
+            'Features\\One\\Tests\\' => 'features/One/tests',
+        ]]);
+});
+
 it('adds package feature classes to namespaces', function () {
     $package = new RootPackage('edalzell/my-features', '1.0', 'v1.1');
     $composer = tap(new Composer)->setPackage($package);


### PR DESCRIPTION
When the package is used inside a Laravel package, features were registered under the `Features\` namespace instead of the package's own namespace. This caused autoload failures during package development.