### PR TITLE
Adopt github-workflows v1.1.2 (branch-based release PR)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,5 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-exclude-labels:
-  - 'release'
 categories:
   - title: '🚀 New'
     labels:

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   draft:
-    uses: edalzell/github-workflows/.github/workflows/release-draft.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
+    uses: edalzell/github-workflows/.github/workflows/release-draft.yml@0ccc48350b3c3e6a02c626526468e905dd0b59d0 # v1.1.2
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   draft:
-    uses: edalzell/github-workflows/.github/workflows/release-draft.yml@f6f95441899dd87addad89818061ce0100b22862 # v1.1.0
+    uses: edalzell/github-workflows/.github/workflows/release-draft.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prepare:
-    uses: edalzell/github-workflows/.github/workflows/release-prepare.yml@f6f95441899dd87addad89818061ce0100b22862 # v1.1.0
+    uses: edalzell/github-workflows/.github/workflows/release-prepare.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prepare:
-    uses: edalzell/github-workflows/.github/workflows/release-prepare.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
+    uses: edalzell/github-workflows/.github/workflows/release-prepare.yml@0ccc48350b3c3e6a02c626526468e905dd0b59d0 # v1.1.2
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,9 +6,6 @@ on:
 
 jobs:
   publish:
-    if: >-
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: edalzell/github-workflows/.github/workflows/release-publish.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
+    uses: edalzell/github-workflows/.github/workflows/release-publish.yml@0ccc48350b3c3e6a02c626526468e905dd0b59d0 # v1.1.2
     permissions:
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     if: >-
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release')
-    uses: edalzell/github-workflows/.github/workflows/release-publish.yml@f6f95441899dd87addad89818061ce0100b22862 # v1.1.0
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    uses: edalzell/github-workflows/.github/workflows/release-publish.yml@2bcb000b0c2aba1e5f15e2d5d86a26be4f89cd83 # v1.1.1
     permissions:
       contents: write


### PR DESCRIPTION
Follow-up to #77. The v1.1.0 flow identified the release PR by a `release` label, but creating that label needs `Issues: write` on the `RELEASE_TOKEN` PAT — so **Release Prepare** failed with `403 Resource not accessible by personal access token` on `/labels`.

v1.1.2 drops the label and recognises the release PR by its `release/*` branch instead, so the PAT needs only **Contents + Pull requests write** (what it already has). The merge + branch guard now lives inside the shared `release-publish` workflow, so this caller doesn't need an `if` either.

- Re-pin all three callers to **v1.1.2** (`0ccc483`).
- **release-publish**: no `if` — the shared workflow guards on merge + `release/*` branch.
- Remove `exclude-labels: ['release']` from `release-drafter.yml` — there's no label anymore, and `release-draft` already skips `release/*` PRs.

After merge, re-run **Release Prepare** — the existing PAT should now get all the way through to opening the PR.