### PR TITLE
Derive the feature path from the provider's own location

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,42 @@ In a package, `registerFeatures()` defaults to looking in `<package-root>/featur
 $this->registerFeatures('/path/to/features', 'My\\Namespace\\Features');
 ```
 
+### Features outside the app
+
+A feature works from anywhere — the app, a package, or a directory outside the app entirely, such as a monorepo where two apps share one set of features:
+
+```
+gym/
+├── apps/
+│   ├── server/
+│   └── mobile/
+└── shared/
+    └── features/
+        └── Scheduling/
+```
+
+Two things need wiring, in each app that uses them.
+
+**Autoloading** — declare the directory and its namespace in `composer.json`, and the plugin generates PSR-4 entries for every feature it finds:
+
+```json
+"extra": {
+    "laravel-features": {
+        "paths": {
+            "../../shared/features": "Shared\\Features"
+        }
+    }
+}
+```
+
+**Registration** — point `registerFeatures()` at the same directory:
+
+```php
+$this->registerFeatures(base_path('../../shared/features'), 'Shared\\Features');
+```
+
+The app's own `features/` directory is still scanned, so app-local and shared features can coexist.
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "autoload-dev": {
         "psr-4": {
             "Edalzell\\Features\\Tests\\": "tests/",
-            "Edalzell\\Features\\Tests\\Fixtures\\": "tests/__fixtures__/"
+            "Edalzell\\Features\\Tests\\Fixtures\\": "tests/__fixtures__/",
+            "Edalzell\\Features\\Tests\\Fixtures\\Sibling\\": "tests/__fixtures__/Sibling/src"
         }
     },
     "config": {

--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -6,6 +6,7 @@ use Edalzell\Features\Features;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use ReflectionClass;
+use RuntimeException;
 
 abstract class FeatureServiceProvider extends LaravelServiceProvider
 {
@@ -50,12 +51,28 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
 
     protected function featuresPath(): string
     {
-        return base_path('features/'.$this->name());
+        return $this->directory();
     }
 
     protected function name(): string
     {
-        return basename(dirname((new ReflectionClass(static::class))->getFileName(), 2));
+        return basename($this->directory());
+    }
+
+    /**
+     * The feature's root directory, derived from this provider's own location
+     * (`<feature>/src/ServiceProvider.php`) so a feature works wherever it
+     * lives — the app, a package, or a directory outside the app entirely.
+     */
+    private function directory(): string
+    {
+        $file = (new ReflectionClass(static::class))->getFileName();
+
+        if ($file === false) {
+            throw new RuntimeException('Unable to determine the feature directory for ['.static::class.'].');
+        }
+
+        return dirname($file, 2);
     }
 
     protected function slug(): string

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -59,8 +59,18 @@ function tidy(string $path): string
     return str_replace('/', '\\', $path);
 }
 
+function fixturePath(string $path = ''): string
+{
+    return rtrim(__DIR__.'/__fixtures__/'.$path, '/');
+}
+
 class TestServiceProvider extends FeatureServiceProvider
 {
+    protected function featuresPath(): string
+    {
+        return base_path('features/TwoWords');
+    }
+
     protected function name(): string
     {
         return 'TwoWords';

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -124,16 +124,19 @@ it('adds seeders via boot', function () {
 it('loads migrations for a feature outside the app features directory', function () {
     (new SiblingServiceProvider(app()))->register();
 
-    expect(app('migrator')->paths())->toContain(fixturePath('Sibling/database/migrations'));
+    expect(array_map(tidy(...), app('migrator')->paths()))
+        ->toContain(tidy(fixturePath('Sibling/database/migrations')));
 });
 
 it('derives the feature name and slug from the provider location', function () {
     (new SiblingServiceProvider(app()))->register();
 
-    expect(view()->getFinder()->getHints())
+    $hints = view()->getFinder()->getHints();
+
+    expect($hints)
         ->toHaveKey('sibling')
-        ->and(view()->getFinder()->getHints()['sibling'])
-        ->toContain(fixturePath('Sibling/resources/views'));
+        ->and(array_map(tidy(...), $hints['sibling']))
+        ->toContain(tidy(fixturePath('Sibling/resources/views')));
 });
 
 class TestGroupedServiceProvider extends FeatureServiceProvider

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 use Edalzell\Features\Providers\FeatureServiceProvider;
 use Edalzell\Features\SeedersFacade;
+use Edalzell\Features\Tests\Fixtures\Sibling\ServiceProvider as SiblingServiceProvider;
 use Illuminate\Foundation\Application;
 
 it('publishes config', function () {
@@ -120,8 +121,28 @@ it('adds seeders via boot', function () {
     $provider->boot();
 });
 
+it('loads migrations for a feature outside the app features directory', function () {
+    (new SiblingServiceProvider(app()))->register();
+
+    expect(app('migrator')->paths())->toContain(fixturePath('Sibling/database/migrations'));
+});
+
+it('derives the feature name and slug from the provider location', function () {
+    (new SiblingServiceProvider(app()))->register();
+
+    expect(view()->getFinder()->getHints())
+        ->toHaveKey('sibling')
+        ->and(view()->getFinder()->getHints()['sibling'])
+        ->toContain(fixturePath('Sibling/resources/views'));
+});
+
 class TestGroupedServiceProvider extends FeatureServiceProvider
 {
+    protected function featuresPath(): string
+    {
+        return base_path('features/TwoWords');
+    }
+
     protected function configGroup(): string
     {
         return 'admin';

--- a/tests/__fixtures__/Sibling/database/migrations/create_siblings_table.php
+++ b/tests/__fixtures__/Sibling/database/migrations/create_siblings_table.php
@@ -1,0 +1,3 @@
+<?php
+
+// Intentionally empty — presence is what registerMigrations() looks for.

--- a/tests/__fixtures__/Sibling/resources/views/show.blade.php
+++ b/tests/__fixtures__/Sibling/resources/views/show.blade.php
@@ -1,0 +1,1 @@
+{{-- Intentionally empty — presence is what registerViews() looks for. --}}

--- a/tests/__fixtures__/Sibling/src/ServiceProvider.php
+++ b/tests/__fixtures__/Sibling/src/ServiceProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Edalzell\Features\Tests\Fixtures\Sibling;
+
+use Edalzell\Features\Providers\FeatureServiceProvider;
+
+/**
+ * A feature that lives outside the app's `features/` directory, autoloaded the
+ * same way the composer plugin autoloads one: namespace -> <feature>/src.
+ */
+class ServiceProvider extends FeatureServiceProvider {}


### PR DESCRIPTION
## Problem

`FeatureServiceProvider::featuresPath()` defaulted to `base_path('features/'.$this->name())`, which assumes every feature lives in the app's own `features/` directory.

For a feature anywhere else — a package, or a shared directory in a monorepo — that path does not exist, so `Features` finds nothing and config, migrations, routes, views, policies, listeners and seeders all silently no-op. No error; the feature just does nothing.

```php
// shared/features/Scheduling/src/ServiceProvider.php
class ServiceProvider extends FeatureServiceProvider {}

// featuresPath() -> base_path('features/Scheduling')   <- does not exist
// actual location -> shared/features/Scheduling
```

## Change

Derives it from the provider's own file, which is where `name()` already came from:

```php
private function directory(): string   // <feature>/src/ServiceProvider.php -> <feature>
```

`featuresPath()` and `name()` now both read from it, so they can no longer disagree. Unchanged for app-local features — `features/Foo/src/ServiceProvider.php` still resolves to `features/Foo`.

## Tests

New fixture feature at `tests/__fixtures__/Sibling`, autoloaded exactly as the composer plugin autoloads a real one, asserting migrations and views register from the fixture's own directory. Both tests fail on `main`.

The existing `TestServiceProvider` / `TestGroupedServiceProvider` fixtures are declared in test files rather than a feature directory, so they now set `featuresPath()` explicitly.

## Notes

Pairs with edalzell/laravel-features-plugin#9 (https://github.com/edalzell/laravel-features-plugin/pull/9), which handles the autoload half.