### PR TITLE
Require laravel-features-plugin ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "composer/composer": "^2.8",
-        "edalzell/laravel-features-plugin": "^0.1",
+        "edalzell/laravel-features-plugin": "^0.2",
         "illuminate/contracts": "^12.0 || ^13.0"
     },
     "require-dev": {


### PR DESCRIPTION
Follow-up to #81.

#81 documented features living outside the app root, but the constraint on the composer plugin was left at `^0.1`. That excludes plugin v0.2.0, which is what actually generates the PSR-4 entries for those directories — so the documented setup installs but does not work, and requiring the plugin directly conflicts:

```
edalzell/laravel-features v0.6.2 requires edalzell/laravel-features-plugin ^0.1
  -> found v0.1.0 but it conflicts with your root composer.json require (^0.2)
```

Bumps it to `^0.2`. Plugin v0.2.0 is additive, so nothing else changes.