### PR TITLE
Put feature route files in their conventional route groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,43 @@ Each feature behaves like a mini Laravel app. The following are auto-registered 
 | Register | Config, Migrations, Routes, Seeders, Views |
 | Boot | Config publishing, Listeners, Policies, Seeders |
 
+## Route groups
+
+A feature's route files are put in a route group, chosen by filename, the same way the framework does it for an application's own route files:
+
+| File | Group |
+|---|---|
+| `routes/web.php` | `web` middleware |
+| `routes/api.php` | `api` middleware, `api` prefix |
+| anything else | no middleware group, no prefix |
+
+Without this, `loadRoutesFrom()` is a bare `require` — a feature's `routes/web.php` would get no session or CSRF, and `routes/api.php` no throttling and no prefix.
+
+Publish the config to change a group for all features at once — to add an API version, for example:
+
+```bash
+php artisan vendor:publish --tag=features-config
+```
+
+```php
+// config/features.php
+'route_groups' => [
+    'web' => ['middleware' => 'web'],
+    'api' => ['middleware' => 'api', 'prefix' => 'api/v1', 'as' => 'api.v1.'],
+],
+```
+
+Or override `routeGroups()` on one feature's service provider:
+
+```php
+protected function routeGroups(): array
+{
+    return ['api' => ['middleware' => ['api', 'auth:sanctum'], 'prefix' => 'api/internal']];
+}
+```
+
+Set an entry to `null`, or remove it, and that file gets no middleware group and no prefix — only what it declares itself.
+
 ## Installation
 
 You can install the package via composer:
@@ -73,7 +110,8 @@ Override any of these protected methods to customise behaviour:
 protected function configFileName(): string      // default: kebab-cased feature name
 protected function configGroup(): string         // default: '' (no subdirectory)
 protected function configPublishHandle(): string // default: kebab-cased feature name
-protected function featuresPath(): string        // default: base_path('features/FeatureName')
+protected function featuresPath(): string        // default: derived from the provider's own location
+protected function routeGroups(): array          // default: config('features.route_groups')
 ```
 
 ### Option 2: Standalone `Features` object

--- a/config/features.php
+++ b/config/features.php
@@ -3,4 +3,26 @@
 // config for Edalzell/Features
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route groups
+    |--------------------------------------------------------------------------
+    |
+    | Keyed by route filename without extension. A feature's `routes/web.php` and
+    | `routes/api.php` are put in a route group the same way the framework does it
+    | for an application's own, so they get session and CSRF, or the API middleware
+    | and prefix, without each feature declaring it. A filename with no entry here
+    | gets no middleware group and no prefix — only what the file declares itself.
+    |
+    | Change a group here and it applies to every feature — adding an API version,
+    | say. To change it for just one feature, override `routeGroups()` on that
+    | feature's service provider.
+    |
+    */
+
+    'route_groups' => [
+        'web' => ['middleware' => 'web'],
+        'api' => ['middleware' => 'api', 'prefix' => 'api'],
+    ],
+
 ];

--- a/src/Features.php
+++ b/src/Features.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Events\DiscoverEvents;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use ReflectionClass;
@@ -34,6 +35,9 @@ class Features
     private string $namespace;
 
     private string $path;
+
+    /** @var array<string, array<string, mixed>> */
+    private array $routeGroups = [];
 
     public function __construct(private readonly ServiceProvider $provider)
     {
@@ -192,11 +196,41 @@ class Features
         }
 
         collect($this->finder('routes'))
-            ->map(fn (SplFileInfo $file) => $file->getRealPath())
-            ->filter()
-            ->each(fn (string $routePath) => $this->callProtected('loadRoutesFrom', $routePath));
+            ->each(fn (SplFileInfo $file) => $this->loadRouteFile($file));
 
         return $this;
+    }
+
+    /**
+     * `loadRoutesFrom()` is a bare require, so without this a feature's
+     * `routes/web.php` gets no `web` middleware — no session, no CSRF — and
+     * `routes/api.php` no `api` middleware and no prefix. The framework puts its own
+     * route files in a group; features should behave like the app.
+     *
+     * @param  array<string, array<string, mixed>>  $groups
+     */
+    public function routeGroups(array $groups): static
+    {
+        $this->routeGroups = $groups;
+
+        return $this;
+    }
+
+    private function loadRouteFile(SplFileInfo $file): void
+    {
+        if (! $path = $file->getRealPath()) {
+            return;
+        }
+
+        $group = $this->routeGroups[$file->getBasename('.php')] ?? null;
+
+        if ($group === null) {
+            $this->callProtected('loadRoutesFrom', $path);
+
+            return;
+        }
+
+        Route::group($group, fn () => $this->callProtected('loadRoutesFrom', $path));
     }
 
     public function registerSeeders(): static

--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -21,7 +21,8 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
             ->name($this->name())
             ->configFileName($this->configFileName())
             ->configGroup($this->configGroup())
-            ->configPublishHandle($this->configPublishHandle());
+            ->configPublishHandle($this->configPublishHandle())
+            ->routeGroups($this->routeGroups());
     }
 
     public function boot(): void
@@ -37,6 +38,23 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
     protected function configFileName(): string
     {
         return $this->slug();
+    }
+
+    /**
+     * Keyed by route filename without extension. Matches how the framework groups an
+     * application's own route files, so `routes/web.php` and `routes/api.php` behave
+     * the same inside a feature. Override this to change a group for one feature, or
+     * set `features.route_groups` to change it for all of them. A filename with no
+     * entry gets no middleware group and no prefix — only what the file declares.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected function routeGroups(): array
+    {
+        return config('features.route_groups', [
+            'web' => ['middleware' => 'web'],
+            'api' => ['middleware' => 'api', 'prefix' => 'api'],
+        ]);
     }
 
     protected function configGroup(): string

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,11 +14,17 @@ class ServiceProvider extends LaravelServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands(Make::class);
+
+            $this->publishes([
+                __DIR__.'/../config/features.php' => config_path('features.php'),
+            ], 'features-config');
         }
     }
 
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/features.php', 'features');
+
         $this->registerFeatures(base_path('features'), 'Features');
     }
 }

--- a/tests/RouteGroupsTest.php
+++ b/tests/RouteGroupsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Edalzell\Features\Tests\Fixtures\Sibling\ServiceProvider as SiblingServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+function siblingRoute(string $name): ?Illuminate\Routing\Route
+{
+    return collect(Route::getRoutes()->getRoutes())
+        ->first(fn (Illuminate\Routing\Route $route) => $route->getName() === $name);
+}
+
+it('puts routes/web.php in the web middleware group', function () {
+    (new SiblingServiceProvider(app()))->register();
+
+    expect(siblingRoute('sibling.web')?->gatherMiddleware())->toContain('web');
+});
+
+it('puts routes/api.php in the api group and prefixes it', function () {
+    (new SiblingServiceProvider(app()))->register();
+
+    $route = siblingRoute('sibling.api');
+
+    expect($route?->uri())->toBe('api/sibling-api')
+        ->and($route?->gatherMiddleware())->toContain('api');
+});
+
+it('lets the app change a group through config', function () {
+    config()->set('features.route_groups.api', [
+        'middleware' => 'api',
+        'prefix' => 'api/v1',
+        'as' => 'api.v1.',
+    ]);
+
+    (new SiblingServiceProvider(app()))->register();
+
+    expect(siblingRoute('api.v1.sibling.api')?->uri())->toBe('api/v1/sibling-api');
+});
+
+it('lets a feature override its own groups', function () {
+    (new OverridingSiblingServiceProvider(app()))->register();
+
+    expect(siblingRoute('sibling.api')?->uri())->toBe('internal/sibling-api');
+});
+
+it('adds no middleware group or prefix when there is no entry for the file', function () {
+    config()->set('features.route_groups', []);
+
+    (new SiblingServiceProvider(app()))->register();
+
+    expect(siblingRoute('sibling.api')?->uri())->toBe('sibling-api')
+        ->and(siblingRoute('sibling.api')?->gatherMiddleware())->not->toContain('api');
+});
+
+class OverridingSiblingServiceProvider extends SiblingServiceProvider
+{
+    /**
+     * Declared here rather than in the fixture, so the path derived from this
+     * class's own file would point at the package root. Point it back.
+     */
+    protected function featuresPath(): string
+    {
+        return dirname(__DIR__).'/tests/__fixtures__/Sibling';
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    protected function routeGroups(): array
+    {
+        return ['api' => ['prefix' => 'internal']];
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,14 +1,29 @@
 <?php
 
 use Edalzell\Features\ServiceProvider;
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * register() merges the package config before discovering features, so a mocked
+ * Application has to answer the container lookup that mergeConfigFrom makes.
+ */
+function mockApplicationWithConfig(): Application
+{
+    $app = mock(Application::class);
+
+    $app->shouldReceive('make')->with('config')->andReturn(new Repository);
+    $app->shouldReceive('configurationIsCached')->andReturn(false);
+
+    return $app;
+}
 
 it('registers feature', function () {
     File::expects('exists')->with(base_path('features'))->andReturns(true);
     File::expects('directories')->with(base_path('features'))->andReturns([base_path('features/TwoWords')]);
     File::expects('exists')->with(base_path('features/TwoWords').'/src/ServiceProvider.php')->andReturns(true);
 
-    $app = mock(Application::class);
+    $app = mockApplicationWithConfig();
 
     $app
         ->shouldReceive('register')
@@ -24,7 +39,7 @@ it('doesnt register feature when no provider', function () {
     File::expects('directories')->with(base_path('features'))->andReturns([base_path('features/TwoWords')]);
     File::expects('exists')->with(base_path('features/TwoWords').'/src/ServiceProvider.php')->andReturns(false);
 
-    $app = mock(Application::class);
+    $app = mockApplicationWithConfig();
 
     $app->shouldNotReceive('register');
 

--- a/tests/__fixtures__/Sibling/routes/api.php
+++ b/tests/__fixtures__/Sibling/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('sibling-api', fn () => 'ok')->name('sibling.api');

--- a/tests/__fixtures__/Sibling/routes/web.php
+++ b/tests/__fixtures__/Sibling/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('sibling-web', fn () => 'ok')->name('sibling.web');


### PR DESCRIPTION
## Problem

`loadRoutesFrom()` is a bare `require`, so a feature's route files get no middleware at all. The framework puts its own in a group:

```php
Route::middleware('api')->prefix($apiPrefix)->group($api);
```

but a feature's are not. In practice:

- `routes/web.php` runs without the `web` group — no session, no CSRF, no cookie encryption.
- `routes/api.php` runs without `api` middleware or prefix, so `Route::post('tokens', …)` lands at `/tokens`, unthrottled.

Stateless `GET`s work, which is why this isn't loud. Anything relying on session or CSRF silently doesn't.

## Change

Route files are now put in a route group, chosen by filename:

| File | Group |
|---|---|
| `routes/web.php` | `web` middleware |
| `routes/api.php` | `api` middleware, `api` prefix |
| anything else | no middleware group, no prefix |

Change a group in the published config and it applies to every feature — to add an API version, say:

```php
// config/features.php
'route_groups' => [
    'api' => ['middleware' => 'api', 'prefix' => 'api/v1', 'as' => 'api.v1.'],
],
```

Or for one feature via `routeGroups()` on its provider. An entry set to `null` gets no middleware group and no prefix — only what the file declares itself.

The package config was previously never merged or publishable; it now is, under the `features-config` tag.

## Breaking

A feature whose `routes/web.php` already declares `Route::middleware('web')` will now get it twice, and `StartSession` running twice is not harmless. Remove the inner declaration, or set the entry to `null`. Worth a `0.7`.

## Tests

Five covering both defaults, changing a group via config, overriding it per feature, and the fallback for a file with no entry — asserted against real registered routes rather than a mocked `loadRoutesFrom`, since middleware is the point. Two existing `ServiceProviderTest` cases needed a mocked container lookup now that `register()` merges config.
