### PR TITLE
Load a feature's routes on boot rather than register

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,17 @@ Booted:
 * Listeners
 * Livewire components
 * Policies
+* Routes
 * Seeders
 
 Registered:
 * Config
 * Migrations
-* Routes
 * Seeders
 * Views
+
+Routes boot rather than register because a route file may use a macro another package
+defines (`Route::livewire()`), and package registration order is not guaranteed.
 
 There are 2 ways to use it:
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Each feature behaves like a mini Laravel app. The following are auto-registered 
 
 | Phase | What |
 |---|---|
-| Register | Config, Migrations, Routes, Seeders, Views |
-| Boot | Config publishing, Listeners, Livewire components, Policies, Seeders |
+| Register | Config, Migrations, Seeders, Views |
+| Boot | Config publishing, Listeners, Livewire components, Policies, Routes, Seeders |
 
 ## Route groups
 
@@ -43,6 +43,8 @@ A feature's route files are put in a route group, chosen by filename, the same w
 | anything else | no middleware group, no prefix |
 
 Without this, `loadRoutesFrom()` is a bare `require` — a feature's `routes/web.php` would get no session or CSRF, and `routes/api.php` no throttling and no prefix.
+
+Routes are loaded on **boot**, not register. A route file may reach for a macro that another package defines — `Route::livewire()` is the common one — and packages register in discovery order, so this one can run well before the package supplying the macro. Booting happens once every provider has registered, which is also where the framework loads its own route files.
 
 Publish the config to change a group for all features at once — to add an API version, for example:
 

--- a/resources/boost/skills/laravel-features/SKILL.md
+++ b/resources/boost/skills/laravel-features/SKILL.md
@@ -33,10 +33,12 @@ This is the part that fails silently — get a file in the wrong place and nothi
 
 | Phase | What | Source |
 |---|---|---|
-| **register()** | Config (merged), Migrations, Routes, Seeders (container binding), Views | `src/`, `database/`, `routes/`, `resources/views/`, `config/` |
-| **boot()** | Config (published for `vendor:publish`), Listeners, Policies, Seeders (discovered & queued) | `src/Listeners/`, `src/Policies/`, `database/seeders/` |
+| **register()** | Config (merged), Migrations, Seeders (container binding), Views | `database/migrations/`, `resources/views/`, `config/` |
+| **boot()** | Config (published for `vendor:publish`), Listeners, Livewire components, Policies, Routes, Seeders (discovered & queued) | `src/Listeners/`, `src/Livewire/`, `src/Policies/`, `routes/`, `database/seeders/` |
 
-Config and Seeders each do something different at each phase: `register()` merges the config file into `config()` and creates the seeder-runner binding; `boot()` makes the config file publishable and discovers the actual seeder classes to add to the runner. Listeners and Policies are boot-only — they need the container fully wired first, so no equivalent happens during register.
+Config and Seeders each do something different at each phase: `register()` merges the config file into `config()` and creates the seeder-runner binding; `boot()` makes the config file publishable and discovers the actual seeder classes to add to the runner. Listeners, Livewire components, Policies and Routes are boot-only — they need the container fully wired first, so no equivalent happens during register.
+
+Routes are the subtlest of those. A route file may reach for a macro another package defines — `Route::livewire()` most often — and packages register in discovery order, so this package can run long before the one supplying the macro. Loading routes on boot puts them where the framework loads its own.
 
 Everything is discovered by scanning a fixed subfolder — `src/Listeners`, `src/Policies`, `database/seeders`. A class in the wrong folder isn't wired up, and there's no warning: a listener outside `src/Listeners` just never fires, a policy outside `src/Policies` is never registered with `Gate`, a seeder outside `database/seeders` never gets added to the run. Same for the top-level folders: migrations only load from `database/migrations`, config only from `config/<slug>.php` (kebab-case of the feature name, unless overridden), views only from `resources/views`.
 

--- a/src/Features.php
+++ b/src/Features.php
@@ -81,6 +81,7 @@ class Features
             ->bootListeners()
             ->bootLivewireComponents()
             ->bootPolicies()
+            ->bootRoutes()
             ->bootSeeders();
     }
 
@@ -115,6 +116,25 @@ class Features
         $this
             ->discoverPolicies()
             ->each(fn (string $policy, string $model) => Gate::policy($model, $policy));
+
+        return $this;
+    }
+
+    /**
+     * Booted, not registered. A feature's route file may reach for a macro another
+     * package defines — `Route::livewire()` is the common one — and packages are
+     * registered in discovery order, so this package can run long before the one
+     * that supplies the macro. Booting happens once every provider has registered,
+     * which is also where the framework's own route files are loaded.
+     */
+    public function bootRoutes(): static
+    {
+        if (! $this->disk()->exists('routes')) {
+            return $this;
+        }
+
+        collect($this->finder('routes'))
+            ->each(fn (SplFileInfo $file) => $this->loadRouteFile($file));
 
         return $this;
     }
@@ -201,7 +221,6 @@ class Features
         $this
             ->registerConfig()
             ->registerMigrations()
-            ->registerRoutes()
             ->registerSeeders()
             ->registerViews();
     }
@@ -213,18 +232,6 @@ class Features
         }
 
         $this->callProtected('loadMigrationsFrom', $this->disk()->path('database/migrations'));
-
-        return $this;
-    }
-
-    public function registerRoutes(): static
-    {
-        if (! $this->disk()->exists('routes')) {
-            return $this;
-        }
-
-        collect($this->finder('routes'))
-            ->each(fn (SplFileInfo $file) => $this->loadRouteFile($file));
 
         return $this;
     }
@@ -242,23 +249,6 @@ class Features
         $this->routeGroups = $groups;
 
         return $this;
-    }
-
-    private function loadRouteFile(SplFileInfo $file): void
-    {
-        if (! $path = $file->getRealPath()) {
-            return;
-        }
-
-        $group = $this->routeGroups[$file->getBasename('.php')] ?? null;
-
-        if ($group === null) {
-            $this->callProtected('loadRoutesFrom', $path);
-
-            return;
-        }
-
-        Route::group($group, fn () => $this->callProtected('loadRoutesFrom', $path));
     }
 
     public function registerSeeders(): static
@@ -416,6 +406,23 @@ class Features
     private function livewireRootNamespace(): string
     {
         return "{$this->namespace}\\Livewire";
+    }
+
+    private function loadRouteFile(SplFileInfo $file): void
+    {
+        if (! $path = $file->getRealPath()) {
+            return;
+        }
+
+        $group = $this->routeGroups[$file->getBasename('.php')] ?? null;
+
+        if ($group === null) {
+            $this->callProtected('loadRoutesFrom', $path);
+
+            return;
+        }
+
+        Route::group($group, fn () => $this->callProtected('loadRoutesFrom', $path));
     }
 
     /** @return array<string, string> */

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -58,7 +58,7 @@ it('can load routes', function () {
         ->once()
         ->withArgs(fn (string $path) => tidy($path) === tidy($disk->path('routes/web.php')));
 
-    $features->registerRoutes();
+    $features->bootRoutes();
 });
 
 it('wont load routes if there arent any', function () {
@@ -67,7 +67,7 @@ it('wont load routes if there arent any', function () {
 
     $provider->shouldNotReceive('loadRoutesFrom');
 
-    $features->registerRoutes();
+    $features->bootRoutes();
 });
 
 it('can load views', function () {
@@ -197,7 +197,7 @@ it('loads all route files', function () {
 
     $provider->shouldReceive('loadRoutesFrom')->twice();
 
-    $features->registerRoutes();
+    $features->bootRoutes();
 });
 
 it('registers the seeders singleton', function () {

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -88,7 +88,7 @@ it('loads migrations via register', function () {
     $provider->register();
 });
 
-it('loads routes via register', function () {
+it('loads routes via boot', function () {
     $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('routes/web.php', '');
     $provider = mockServiceProvider(TestServiceProvider::class);
 
@@ -96,6 +96,18 @@ it('loads routes via register', function () {
         ->shouldReceive('loadRoutesFrom')
         ->once()
         ->withArgs(fn (string $path) => tidy($path) === tidy($disk->path('routes/web.php')));
+
+    $provider->boot();
+});
+
+it('doesnt load routes via register', function () {
+    tap(mockOnDemandDisk('features/TwoWords'))->put('routes/web.php', '');
+    $provider = mockServiceProvider(TestServiceProvider::class);
+
+    // Registering is too early: a route file may call a macro — `Route::livewire()`
+    // — that another package only defines when its own provider registers, and
+    // discovery order can put this package first.
+    $provider->shouldNotReceive('loadRoutesFrom');
 
     $provider->register();
 });

--- a/tests/RouteGroupsTest.php
+++ b/tests/RouteGroupsTest.php
@@ -10,13 +10,13 @@ function siblingRoute(string $name): ?Illuminate\Routing\Route
 }
 
 it('puts routes/web.php in the web middleware group', function () {
-    (new SiblingServiceProvider(app()))->register();
+    (new SiblingServiceProvider(app()))->boot();
 
     expect(siblingRoute('sibling.web')?->gatherMiddleware())->toContain('web');
 });
 
 it('puts routes/api.php in the api group and prefixes it', function () {
-    (new SiblingServiceProvider(app()))->register();
+    (new SiblingServiceProvider(app()))->boot();
 
     $route = siblingRoute('sibling.api');
 
@@ -31,13 +31,13 @@ it('lets the app change a group through config', function () {
         'as' => 'api.v1.',
     ]);
 
-    (new SiblingServiceProvider(app()))->register();
+    (new SiblingServiceProvider(app()))->boot();
 
     expect(siblingRoute('api.v1.sibling.api')?->uri())->toBe('api/v1/sibling-api');
 });
 
 it('lets a feature override its own groups', function () {
-    (new OverridingSiblingServiceProvider(app()))->register();
+    (new OverridingSiblingServiceProvider(app()))->boot();
 
     expect(siblingRoute('sibling.api')?->uri())->toBe('internal/sibling-api');
 });
@@ -45,7 +45,7 @@ it('lets a feature override its own groups', function () {
 it('adds no middleware group or prefix when there is no entry for the file', function () {
     config()->set('features.route_groups', []);
 
-    (new SiblingServiceProvider(app()))->register();
+    (new SiblingServiceProvider(app()))->boot();
 
     expect(siblingRoute('sibling.api')?->uri())->toBe('sibling-api')
         ->and(siblingRoute('sibling.api')?->gatherMiddleware())->not->toContain('api');


### PR DESCRIPTION
A feature whose `routes/web.php` calls `Route::livewire()` fails with **`Attribute [livewire] does not exist`** when the feature lives in an app's own `features/` directory.

`ServiceProvider::register()` calls `registerFeatures(base_path('features'), 'Features')`, and `registerFeature()` loaded route files during **register**. Packages register in discovery order, and this package is often early — in the app that surfaced this, `edalzell/laravel-features` was position 1 and `livewire/livewire` position 14. So the route file ran before Livewire had defined its macro.

Features under `shared/`-style directories never hit it, because a provider listed in `bootstrap/providers.php` registers after every auto-discovered package. The bug only appears for features an app auto-discovers from its own `features/` — the case `ServiceProvider::register()` exists to support.

## Change

`registerRoutes()` becomes `bootRoutes()` and moves from `registerFeature()` to `bootFeature()`. That is where the framework loads its own route files, and it matches the reasoning already applied to `bootLivewireComponents()`, whose docblock says the same thing: *"The binding is only there once Livewire's service provider has run."*

Renamed rather than kept as `registerRoutes()` so the name states the phase, consistent with the other `boot*` methods. Pre-1.0, and the method is only meaningful to callers driving a `Features` object by hand.

Also moved `loadRouteFile()` into the private group in alphabetical order — it was sitting between two public methods.

## Tests

- `loads routes via register` → `loads routes via boot`.
- New: `doesnt load routes via register`, so the ordering cannot silently regress.
- `RouteGroupsTest` drives the provider through `boot()` instead of `register()`.

The suite could not have caught this: `TestCase::getPackageProviders()` returns `[LivewireServiceProvider::class, ServiceProvider::class]` — Livewire first, the opposite of the discovery order that breaks. The new register-side assertion tests the contract directly rather than relying on provider order.

66 tests pass, PHPStan clean, Pint clean.

## Docs

`README.md`, `CLAUDE.md` and the Boost skill all listed Routes under Register. The skill's table was also missing Livewire components from Boot — it predates #88 — so that is corrected in the same table rather than left half right.