### PR TITLE
Add FeatureRegistry for discovered features

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ app(FeatureRegistry::class)
     });
 ```
 
-`Feature::path()` / `namespace()` with no argument return the feature root. `has()` checks that a relative path exists on disk.
+`registerFeatures()` records each feature via `FeatureRegistry::register()`, which also registers that feature's `ServiceProvider`. `Feature::path()` / `namespace()` with no argument return the feature root. `has()` checks that a relative path exists on disk. Use `FeatureRegistry::add()` when you only need the descriptor without loading the provider (e.g. tests).
 
 ### Features outside the app
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,25 @@ In a package, `registerFeatures()` defaults to looking in `<package-root>/featur
 $this->registerFeatures('/path/to/features', 'My\\Namespace\\Features');
 ```
 
+### Looking up registered features
+
+`registerFeatures()` also records each discovered feature in `FeatureRegistry`. Use that when something outside the feature needs its path or namespace — Setup runners, for example — without re-scanning disk or hardcoding conventions:
+
+```php
+use Edalzell\Features\Feature;
+use Edalzell\Features\FeatureRegistry;
+
+app(FeatureRegistry::class)
+    ->all()
+    ->filter(fn (Feature $feature) => $feature->has('src/Setup'))
+    ->each(function (Feature $feature) {
+        $feature->path('src/Setup');      // absolute path
+        $feature->namespace('Setup');     // App\Features\Mail\Setup
+    });
+```
+
+`Feature::path()` / `namespace()` with no argument return the feature root. `has()` checks that a relative path exists on disk.
+
 ### Features outside the app
 
 A feature works from anywhere — the app, a package, or a directory outside the app entirely, such as a monorepo where two apps share one set of features:

--- a/resources/boost/skills/laravel-features/SKILL.md
+++ b/resources/boost/skills/laravel-features/SKILL.md
@@ -120,6 +120,8 @@ class AppServiceProvider extends ServiceProvider
 
 This scans the target directory for subfolders containing `src/ServiceProvider.php` and registers each as `<namespacePrefix>\<FolderName>\ServiceProvider`. **If a folder is missing `src/ServiceProvider.php`, it's silently skipped** — no error, the feature just doesn't exist as far as the app is concerned. If the folder name and the provider's actual namespace don't match (e.g. after renaming a feature folder without updating its `namespace` declaration), registration throws a "class not found" error at boot — that's the signal to check the namespace against the folder name.
 
+Each discovered feature is also stored on `FeatureRegistry` (`app(FeatureRegistry::class)->all()`). Use `Feature::path()`, `namespace()`, and `has()` when package code needs a feature's location without re-deriving folder/namespace conventions.
+
 ## Adding a feature
 
 ```bash

--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -23,10 +23,6 @@ trait HasFeatures
 
         collect(File::directories($path))
             ->filter(fn (string $dir) => File::exists($dir.'/src/ServiceProvider.php'))
-            ->each(fn (string $dir) => $registry->register(new Feature(
-                name: basename($dir),
-                rootPath: $dir,
-                rootNamespace: $namespacePrefix.'\\'.basename($dir),
-            )));
+            ->each(fn (string $dir) => $registry->register(new Feature($dir, $namespacePrefix)));
     }
 }

--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -23,16 +23,10 @@ trait HasFeatures
 
         collect(File::directories($path))
             ->filter(fn (string $dir) => File::exists($dir.'/src/ServiceProvider.php'))
-            ->each(function (string $dir) use ($namespacePrefix, $registry) {
-                $feature = new Feature(
-                    name: basename($dir),
-                    rootPath: $dir,
-                    rootNamespace: $namespacePrefix.'\\'.basename($dir),
-                );
-
-                $registry->add($feature);
-
-                $this->app->register($feature->namespace().'\\ServiceProvider');
-            });
+            ->each(fn (string $dir) => $registry->register(new Feature(
+                name: basename($dir),
+                rootPath: $dir,
+                rootNamespace: $namespacePrefix.'\\'.basename($dir),
+            )));
     }
 }

--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -2,6 +2,8 @@
 
 namespace Edalzell\Features\Concerns;
 
+use Edalzell\Features\Feature;
+use Edalzell\Features\FeatureRegistry;
 use Illuminate\Support\Facades\File;
 use ReflectionClass;
 
@@ -17,8 +19,24 @@ trait HasFeatures
             return;
         }
 
+        if (! $this->app->bound(FeatureRegistry::class)) {
+            $this->app->singleton(FeatureRegistry::class);
+        }
+
+        $registry = $this->app->make(FeatureRegistry::class);
+
         collect(File::directories($path))
             ->filter(fn (string $dir) => File::exists($dir.'/src/ServiceProvider.php'))
-            ->each(fn (string $dir) => $this->app->register($namespacePrefix.'\\'.basename($dir).'\\ServiceProvider'));
+            ->each(function (string $dir) use ($namespacePrefix, $registry) {
+                $feature = new Feature(
+                    name: basename($dir),
+                    rootPath: $dir,
+                    rootNamespace: $namespacePrefix.'\\'.basename($dir),
+                );
+
+                $registry->add($feature);
+
+                $this->app->register($feature->namespace().'\\ServiceProvider');
+            });
     }
 }

--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -19,10 +19,6 @@ trait HasFeatures
             return;
         }
 
-        if (! $this->app->bound(FeatureRegistry::class)) {
-            $this->app->singleton(FeatureRegistry::class);
-        }
-
         $registry = $this->app->make(FeatureRegistry::class);
 
         collect(File::directories($path))

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Edalzell\Features;
+
+readonly class Feature
+{
+    public function __construct(
+        public string $name,
+        public string $rootPath,
+        public string $rootNamespace,
+    ) {}
+
+    public function has(string $relative = ''): bool
+    {
+        return file_exists($this->path($relative));
+    }
+
+    public function namespace(string $relative = ''): string
+    {
+        if ($relative === '') {
+            return $this->rootNamespace;
+        }
+
+        return $this->rootNamespace.'\\'.trim(str_replace('/', '\\', $relative), '\\');
+    }
+
+    public function path(string $relative = ''): string
+    {
+        if ($relative === '') {
+            return $this->rootPath;
+        }
+
+        return $this->rootPath.'/'.trim(str_replace('\\', '/', $relative), '/');
+    }
+}

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -4,11 +4,17 @@ namespace Edalzell\Features;
 
 readonly class Feature
 {
+    public string $name;
+
+    public string $rootNamespace;
+
     public function __construct(
-        public string $name,
         public string $rootPath,
-        public string $rootNamespace,
-    ) {}
+        string $namespacePrefix,
+    ) {
+        $this->name = basename($this->rootPath);
+        $this->rootNamespace = rtrim($namespacePrefix, '\\').'\\'.$this->name;
+    }
 
     public function has(string $relative = ''): bool
     {

--- a/src/FeatureRegistry.php
+++ b/src/FeatureRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Edalzell\Features;
+
+use Illuminate\Support\Collection;
+
+class FeatureRegistry
+{
+    /** @var array<string, Feature> */
+    private array $features = [];
+
+    public function add(Feature $feature): void
+    {
+        $this->features[$feature->name] = $feature;
+    }
+
+    /** @return Collection<string, Feature> */
+    public function all(): Collection
+    {
+        return collect($this->features);
+    }
+
+    public function get(string $name): ?Feature
+    {
+        return $this->features[$name] ?? null;
+    }
+}

--- a/src/FeatureRegistry.php
+++ b/src/FeatureRegistry.php
@@ -2,12 +2,15 @@
 
 namespace Edalzell\Features;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Collection;
 
 class FeatureRegistry
 {
     /** @var array<string, Feature> */
     private array $features = [];
+
+    public function __construct(private Application $app) {}
 
     public function add(Feature $feature): void
     {
@@ -23,5 +26,12 @@ class FeatureRegistry
     public function get(string $name): ?Feature
     {
         return $this->features[$name] ?? null;
+    }
+
+    public function register(Feature $feature): void
+    {
+        $this->add($feature);
+
+        $this->app->register($feature->namespace().'\\ServiceProvider');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,6 +23,8 @@ class ServiceProvider extends LaravelServiceProvider
 
     public function register(): void
     {
+        $this->app->singleton(FeatureRegistry::class);
+
         $this->mergeConfigFrom(__DIR__.'/../config/features.php', 'features');
 
         $this->registerFeatures(base_path('features'), 'Features');

--- a/tests/Concerns/HasFeaturesTest.php
+++ b/tests/Concerns/HasFeaturesTest.php
@@ -14,7 +14,6 @@ it('registers features at an explicit path and namespace', function () {
     $registry = new FeatureRegistry;
 
     $app = mock(Application::class);
-    $app->shouldReceive('bound')->with(FeatureRegistry::class)->andReturn(true);
     $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn($registry);
     $app->shouldReceive('register')
         ->once()

--- a/tests/Concerns/HasFeaturesTest.php
+++ b/tests/Concerns/HasFeaturesTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Edalzell\Features\Concerns\HasFeatures;
+use Edalzell\Features\FeatureRegistry;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
@@ -10,12 +11,21 @@ it('registers features at an explicit path and namespace', function () {
     File::expects('directories')->with('/features/path')->andReturns(['/features/path/MyFeature']);
     File::expects('exists')->with('/features/path/MyFeature/src/ServiceProvider.php')->andReturns(true);
 
+    $registry = new FeatureRegistry;
+
     $app = mock(Application::class);
+    $app->shouldReceive('bound')->with(FeatureRegistry::class)->andReturn(true);
+    $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn($registry);
     $app->shouldReceive('register')
         ->once()
         ->with('My\\App\\MyFeature\\ServiceProvider');
 
     (new TestHasFeaturesProvider($app))->registerFeatures('/features/path', 'My\\App');
+
+    expect($registry->get('MyFeature'))
+        ->name->toBe('MyFeature')
+        ->rootPath->toBe('/features/path/MyFeature')
+        ->rootNamespace->toBe('My\\App\\MyFeature');
 });
 
 it('skips registration when path does not exist', function () {
@@ -23,6 +33,7 @@ it('skips registration when path does not exist', function () {
 
     $app = mock(Application::class);
     $app->shouldNotReceive('register');
+    $app->shouldNotReceive('make');
 
     (new TestHasFeaturesProvider($app))->registerFeatures('/nonexistent', 'My\\App');
 });

--- a/tests/Concerns/HasFeaturesTest.php
+++ b/tests/Concerns/HasFeaturesTest.php
@@ -11,9 +11,9 @@ it('registers features at an explicit path and namespace', function () {
     File::expects('directories')->with('/features/path')->andReturns(['/features/path/MyFeature']);
     File::expects('exists')->with('/features/path/MyFeature/src/ServiceProvider.php')->andReturns(true);
 
-    $registry = new FeatureRegistry;
-
     $app = mock(Application::class);
+    $registry = new FeatureRegistry($app);
+
     $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn($registry);
     $app->shouldReceive('register')
         ->once()

--- a/tests/FeatureRegistryTest.php
+++ b/tests/FeatureRegistryTest.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Foundation\Application;
 
 it('stores and returns registered features', function () {
     $registry = new FeatureRegistry(mock(Application::class));
-    $mail = new Feature(name: 'Mail', rootPath: '/features/Mail', rootNamespace: 'App\\Features\\Mail');
+    $mail = new Feature('/features/Mail', 'App\\Features');
 
     $registry->add($mail);
 
@@ -18,8 +18,8 @@ it('stores and returns registered features', function () {
 
 it('replaces a feature when the same name is added twice', function () {
     $registry = new FeatureRegistry(mock(Application::class));
-    $first = new Feature(name: 'Mail', rootPath: '/a', rootNamespace: 'A\\Mail');
-    $second = new Feature(name: 'Mail', rootPath: '/b', rootNamespace: 'B\\Mail');
+    $first = new Feature('/a/Mail', 'A');
+    $second = new Feature('/b/Mail', 'B');
 
     $registry->add($first);
     $registry->add($second);
@@ -29,7 +29,7 @@ it('replaces a feature when the same name is added twice', function () {
 });
 
 it('records the feature and registers its service provider', function () {
-    $mail = new Feature(name: 'Mail', rootPath: '/features/Mail', rootNamespace: 'App\\Features\\Mail');
+    $mail = new Feature('/features/Mail', 'App\\Features');
 
     $app = mock(Application::class);
     $app->shouldReceive('register')

--- a/tests/FeatureRegistryTest.php
+++ b/tests/FeatureRegistryTest.php
@@ -2,9 +2,10 @@
 
 use Edalzell\Features\Feature;
 use Edalzell\Features\FeatureRegistry;
+use Illuminate\Contracts\Foundation\Application;
 
 it('stores and returns registered features', function () {
-    $registry = new FeatureRegistry;
+    $registry = new FeatureRegistry(mock(Application::class));
     $mail = new Feature(name: 'Mail', rootPath: '/features/Mail', rootNamespace: 'App\\Features\\Mail');
 
     $registry->add($mail);
@@ -16,7 +17,7 @@ it('stores and returns registered features', function () {
 });
 
 it('replaces a feature when the same name is added twice', function () {
-    $registry = new FeatureRegistry;
+    $registry = new FeatureRegistry(mock(Application::class));
     $first = new Feature(name: 'Mail', rootPath: '/a', rootNamespace: 'A\\Mail');
     $second = new Feature(name: 'Mail', rootPath: '/b', rootNamespace: 'B\\Mail');
 
@@ -25,4 +26,18 @@ it('replaces a feature when the same name is added twice', function () {
 
     expect($registry->all())->toHaveCount(1)
         ->and($registry->get('Mail'))->toBe($second);
+});
+
+it('records the feature and registers its service provider', function () {
+    $mail = new Feature(name: 'Mail', rootPath: '/features/Mail', rootNamespace: 'App\\Features\\Mail');
+
+    $app = mock(Application::class);
+    $app->shouldReceive('register')
+        ->once()
+        ->with('App\\Features\\Mail\\ServiceProvider');
+
+    $registry = new FeatureRegistry($app);
+    $registry->register($mail);
+
+    expect($registry->get('Mail'))->toBe($mail);
 });

--- a/tests/FeatureRegistryTest.php
+++ b/tests/FeatureRegistryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Edalzell\Features\Feature;
+use Edalzell\Features\FeatureRegistry;
+
+it('stores and returns registered features', function () {
+    $registry = new FeatureRegistry;
+    $mail = new Feature(name: 'Mail', rootPath: '/features/Mail', rootNamespace: 'App\\Features\\Mail');
+
+    $registry->add($mail);
+
+    expect($registry->all())->toHaveCount(1)
+        ->and($registry->all()->first())->toBe($mail)
+        ->and($registry->get('Mail'))->toBe($mail)
+        ->and($registry->get('Missing'))->toBeNull();
+});
+
+it('replaces a feature when the same name is added twice', function () {
+    $registry = new FeatureRegistry;
+    $first = new Feature(name: 'Mail', rootPath: '/a', rootNamespace: 'A\\Mail');
+    $second = new Feature(name: 'Mail', rootPath: '/b', rootNamespace: 'B\\Mail');
+
+    $registry->add($first);
+    $registry->add($second);
+
+    expect($registry->all())->toHaveCount(1)
+        ->and($registry->get('Mail'))->toBe($second);
+});

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Edalzell\Features\Feature;
+
+it('joins a relative path onto the feature root', function () {
+    $feature = new Feature(
+        name: 'Mail',
+        rootPath: '/pkg/features/Mail',
+        rootNamespace: 'App\\Features\\Mail',
+    );
+
+    expect($feature->path('src/Setup'))->toBe('/pkg/features/Mail/src/Setup')
+        ->and($feature->path())->toBe('/pkg/features/Mail');
+});
+
+it('appends a relative segment onto the feature namespace', function () {
+    $feature = new Feature(
+        name: 'Mail',
+        rootPath: '/pkg/features/Mail',
+        rootNamespace: 'App\\Features\\Mail',
+    );
+
+    expect($feature->namespace('Setup'))->toBe('App\\Features\\Mail\\Setup')
+        ->and($feature->namespace())->toBe('App\\Features\\Mail');
+});
+
+it('reports whether a relative path exists', function () {
+    $root = sys_get_temp_dir().'/feature-'.uniqid();
+    mkdir($root.'/src/Setup', 0777, true);
+
+    $feature = new Feature(name: 'Mail', rootPath: $root, rootNamespace: 'App\\Features\\Mail');
+
+    expect($feature->has('src/Setup'))->toBeTrue()
+        ->and($feature->has('src/Missing'))->toBeFalse();
+
+    array_map('rmdir', [$root.'/src/Setup', $root.'/src', $root]);
+});

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -3,32 +3,25 @@
 use Edalzell\Features\Feature;
 
 it('joins a relative path onto the feature root', function () {
-    $feature = new Feature(
-        name: 'Mail',
-        rootPath: '/pkg/features/Mail',
-        rootNamespace: 'App\\Features\\Mail',
-    );
+    $feature = new Feature('/pkg/features/Mail', 'App\\Features');
 
     expect($feature->path('src/Setup'))->toBe('/pkg/features/Mail/src/Setup')
         ->and($feature->path())->toBe('/pkg/features/Mail');
 });
 
 it('appends a relative segment onto the feature namespace', function () {
-    $feature = new Feature(
-        name: 'Mail',
-        rootPath: '/pkg/features/Mail',
-        rootNamespace: 'App\\Features\\Mail',
-    );
+    $feature = new Feature('/pkg/features/Mail', 'App\\Features');
 
     expect($feature->namespace('Setup'))->toBe('App\\Features\\Mail\\Setup')
-        ->and($feature->namespace())->toBe('App\\Features\\Mail');
+        ->and($feature->namespace())->toBe('App\\Features\\Mail')
+        ->and($feature->name)->toBe('Mail');
 });
 
 it('reports whether a relative path exists', function () {
     $root = sys_get_temp_dir().'/feature-'.uniqid();
     mkdir($root.'/src/Setup', 0777, true);
 
-    $feature = new Feature(name: 'Mail', rootPath: $root, rootNamespace: 'App\\Features\\Mail');
+    $feature = new Feature($root, 'App\\Features');
 
     expect($feature->has('src/Setup'))->toBeTrue()
         ->and($feature->has('src/Missing'))->toBeFalse();

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Edalzell\Features\FeatureRegistry;
 use Edalzell\Features\ServiceProvider;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\File;
 
 /**
  * register() merges the package config before discovering features, so a mocked
@@ -12,6 +14,9 @@ function mockApplicationWithConfig(): Application
 {
     $app = mock(Application::class);
 
+    $app->shouldReceive('singleton')->with(FeatureRegistry::class)->andReturnNull();
+    $app->shouldReceive('bound')->with(FeatureRegistry::class)->andReturn(true);
+    $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn(new FeatureRegistry);
     $app->shouldReceive('make')->with('config')->andReturn(new Repository);
     $app->shouldReceive('configurationIsCached')->andReturn(false);
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -15,7 +15,7 @@ function mockApplicationWithConfig(): Application
     $app = mock(Application::class);
 
     $app->shouldReceive('singleton')->with(FeatureRegistry::class)->andReturnNull();
-    $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn(new FeatureRegistry);
+    $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn(new FeatureRegistry($app));
     $app->shouldReceive('make')->with('config')->andReturn(new Repository);
     $app->shouldReceive('configurationIsCached')->andReturn(false);
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -15,7 +15,6 @@ function mockApplicationWithConfig(): Application
     $app = mock(Application::class);
 
     $app->shouldReceive('singleton')->with(FeatureRegistry::class)->andReturnNull();
-    $app->shouldReceive('bound')->with(FeatureRegistry::class)->andReturn(true);
     $app->shouldReceive('make')->with(FeatureRegistry::class)->andReturn(new FeatureRegistry);
     $app->shouldReceive('make')->with('config')->andReturn(new Repository);
     $app->shouldReceive('configurationIsCached')->andReturn(false);


### PR DESCRIPTION
## Summary
- Add `Feature` / `FeatureRegistry` so callers can resolve a feature's path and namespace without re-scanning disk or hardcoding conventions.
- `HasFeatures::registerFeatures()` records each discovered feature on the registry; package `ServiceProvider` binds the singleton.

## Test plan
- [x] `composer test`
- [ ] Confirm consumers can use `app(FeatureRegistry::class)->all()` after `registerFeatures()`