### PR TITLE
Prefix config merge key with configGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Override any of these protected methods to customise behaviour:
 
 ```php
 protected function configFileName(): string      // default: kebab-cased feature name
-protected function configGroup(): string         // default: '' (no subdirectory)
+protected function configGroup(): string         // default: '' (no subdirectory); when set, merges as `{group}.{file}` (e.g. prime + mail → config('prime.mail'))
 protected function configPublishHandle(): string // default: kebab-cased feature name
 protected function featuresPath(): string        // default: derived from the provider's own location
 protected function livewireNamespace(): string   // default: kebab-cased feature name

--- a/resources/boost/skills/laravel-features/SKILL.md
+++ b/resources/boost/skills/laravel-features/SKILL.md
@@ -75,7 +75,7 @@ Override any of these to customize:
 
 ```php
 protected function configFileName(): string      // default: kebab-cased feature name
-protected function configGroup(): string         // default: '' (no subdirectory)
+protected function configGroup(): string         // default: '' (no subdirectory); when set, merges as `{group}.{file}`
 protected function configPublishHandle(): string  // default: kebab-cased feature name
 protected function featuresPath(): string         // default: derived from this class's own file location
 protected function routeGroups(): array           // default: config('features.route_groups')

--- a/src/Features.php
+++ b/src/Features.php
@@ -59,15 +59,13 @@ class Features
             return $this;
         }
 
-        $configFile = $this->configFileName.'.php';
-
-        if (! $this->disk()->exists($path = 'config/'.$configFile)) {
+        if (! $this->disk()->exists($path = $this->configRelativePath())) {
             return $this;
         }
 
         $this->callProtected(
             'publishes',
-            [$this->disk()->path($path) => config_path($this->join('/', $this->configGroup, $configFile))],
+            [$this->disk()->path($path) => config_path($this->join('/', $this->configGroup, $this->configFileName.'.php'))],
             $this->join('-', $this->configPublishHandle, 'config'),
         );
 
@@ -205,13 +203,11 @@ class Features
 
     public function registerConfig(): static
     {
-        if (! $this->disk()->exists('config/'.$this->configFileName.'.php')) {
+        if (! $this->disk()->exists($path = $this->configRelativePath())) {
             return $this;
         }
 
-        $path = $this->join('/', 'config', $this->configGroup, $this->configFileName.'.php');
-
-        $this->callProtected('mergeConfigFrom', $this->disk()->path($path), $this->configFileName);
+        $this->callProtected('mergeConfigFrom', $this->disk()->path($path), $this->configMergeKey());
 
         return $this;
     }
@@ -314,6 +310,16 @@ class Features
     private function callProtected(string $method, mixed ...$args): mixed
     {
         return (new ReflectionMethod($this->provider, $method))->invoke($this->provider, ...$args);
+    }
+
+    private function configMergeKey(): string
+    {
+        return $this->join('.', $this->configGroup, $this->configFileName);
+    }
+
+    private function configRelativePath(): string
+    {
+        return $this->join('/', 'config', $this->configGroup, $this->configFileName.'.php');
     }
 
     /** @return array<string, array<string>> */

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -121,14 +121,14 @@ it('can register policies', function () {
 });
 
 it('merges config when it exists in group directory', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
     [$features, $provider] = mockFeatures();
     $features->configGroup('admin');
 
     $provider
         ->shouldReceive('mergeConfigFrom')
         ->once()
-        ->with($disk->path('config/admin/two-words.php'), 'two-words');
+        ->with($disk->path('config/admin/two-words.php'), 'admin.two-words');
 
     $features->registerConfig();
 });
@@ -141,6 +141,22 @@ it('wont merge config when group directory config does not exist', function () {
     $provider->shouldNotReceive('mergeConfigFrom');
 
     $features->registerConfig();
+});
+
+it('publishes grouped config from the group directory', function () {
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
+    [$features, $provider] = mockFeatures();
+    $features->configGroup('admin');
+
+    $provider
+        ->shouldReceive('publishes')
+        ->once()
+        ->with(
+            [$disk->path('config/admin/two-words.php') => config_path('admin/two-words.php')],
+            'two-words-config',
+        );
+
+    $features->bootConfig();
 });
 
 it('publishes config when running in console', function () {

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -50,14 +50,14 @@ it('merges config via register', function () {
 });
 
 it('publishes config to group directory when group is set', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
     $provider = mockServiceProvider(TestGroupedServiceProvider::class);
 
     $provider
         ->shouldReceive('publishes')
         ->once()
         ->with(
-            [$disk->path('config/two-words.php') => config_path('admin/two-words.php')],
+            [$disk->path('config/admin/two-words.php') => config_path('admin/two-words.php')],
             'admin-two-words-config'
         );
 
@@ -65,13 +65,13 @@ it('publishes config to group directory when group is set', function () {
 });
 
 it('merges config from group directory via register', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
     $provider = mockServiceProvider(TestGroupedServiceProvider::class);
 
     $provider
         ->shouldReceive('mergeConfigFrom')
         ->once()
-        ->with($disk->path('config/admin/two-words.php'), 'two-words');
+        ->with($disk->path('config/admin/two-words.php'), 'admin.two-words');
 
     $provider->register();
 });


### PR DESCRIPTION
## Summary
When `configGroup` is set, config was still merged under the bare file name (e.g. group `prime` + file `mail` → `config('mail')`), colliding with Laravel. The exists-check also looked at `config/{file}.php` even when the publish path used the group subdirectory.

Merge key is now `{group}.{file}` (nested via Laravel’s `Arr::set`), and the exists-check uses the same grouped relative path as publish.

## Test plan
- [x] Pest: grouped merge key `admin.two-words`, grouped exists-check, grouped publish
- [ ] Merge, then run Release Prepare for patch `0.9.1`