### PR TITLE
Keep feature config files flat; derive configGroup from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Override any of these protected methods to customise behaviour:
 
 ```php
 protected function configFileName(): string      // default: kebab-cased feature name
-protected function configGroup(): string         // default: '' (no subdirectory); when set, merges as `{group}.{file}` (e.g. prime + mail → config('prime.mail'))
+protected function configGroup(): string         // default: host Composer package short name when registered via package `features/` (e.g. transformstudios/prime → prime); merge key `{group}.{file}`, publish to `config/{group}/{file}.php`
 protected function configPublishHandle(): string // default: kebab-cased feature name
 protected function featuresPath(): string        // default: derived from the provider's own location
 protected function livewireNamespace(): string   // default: kebab-cased feature name

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,8 @@
         "psr-4": {
             "Edalzell\\Features\\Tests\\": "tests/",
             "Edalzell\\Features\\Tests\\Fixtures\\": "tests/__fixtures__/",
+            "Edalzell\\Features\\Tests\\Fixtures\\PackageHost\\": "tests/__fixtures__/PackageHost/src",
+            "Edalzell\\Features\\Tests\\Fixtures\\PackageHost\\Features\\SecureHeaders\\": "tests/__fixtures__/PackageHost/features/SecureHeaders/src",
             "Edalzell\\Features\\Tests\\Fixtures\\Sibling\\": "tests/__fixtures__/Sibling/src"
         }
     },

--- a/resources/boost/skills/laravel-features/SKILL.md
+++ b/resources/boost/skills/laravel-features/SKILL.md
@@ -75,7 +75,7 @@ Override any of these to customize:
 
 ```php
 protected function configFileName(): string      // default: kebab-cased feature name
-protected function configGroup(): string         // default: '' (no subdirectory); when set, merges as `{group}.{file}`
+protected function configGroup(): string         // default: host Composer package short name for package features; merge `{group}.{file}`, publish under `config/{group}/`
 protected function configPublishHandle(): string  // default: kebab-cased feature name
 protected function featuresPath(): string         // default: derived from this class's own file location
 protected function routeGroups(): array           // default: config('features.route_groups')

--- a/src/Concerns/HasFeatures.php
+++ b/src/Concerns/HasFeatures.php
@@ -12,17 +12,37 @@ trait HasFeatures
     public function registerFeatures(?string $path = null, ?string $namespacePrefix = null): void
     {
         $reflection = new ReflectionClass($this);
-        $path ??= dirname($reflection->getFileName(), 2).'/features';
+        $packageRoot = dirname($reflection->getFileName(), 2);
+        $usingPackageFeatures = $path === null;
+        $path ??= $packageRoot.'/features';
         $namespacePrefix ??= $reflection->getNamespaceName().'\\Features';
 
         if (! File::exists($path)) {
             return;
         }
 
+        $configGroup = $usingPackageFeatures ? $this->packageConfigGroup($packageRoot) : '';
         $registry = $this->app->make(FeatureRegistry::class);
 
         collect(File::directories($path))
             ->filter(fn (string $dir) => File::exists($dir.'/src/ServiceProvider.php'))
-            ->each(fn (string $dir) => $registry->register(new Feature($dir, $namespacePrefix)));
+            ->each(fn (string $dir) => $registry->register(new Feature($dir, $namespacePrefix, $configGroup)));
+    }
+
+    private function packageConfigGroup(string $packageRoot): string
+    {
+        $composerPath = $packageRoot.'/composer.json';
+
+        if (! File::exists($composerPath)) {
+            return '';
+        }
+
+        $name = json_decode(File::get($composerPath), true)['name'] ?? null;
+
+        if (! is_string($name) || ! str_contains($name, '/')) {
+            return '';
+        }
+
+        return basename($name);
     }
 }

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -11,6 +11,7 @@ readonly class Feature
     public function __construct(
         public string $rootPath,
         string $namespacePrefix,
+        public string $configGroup = '',
     ) {
         $this->name = basename($this->rootPath);
         $this->rootNamespace = rtrim($namespacePrefix, '\\').'\\'.$this->name;

--- a/src/Features.php
+++ b/src/Features.php
@@ -319,7 +319,7 @@ class Features
 
     private function configRelativePath(): string
     {
-        return $this->join('/', 'config', $this->configGroup, $this->configFileName.'.php');
+        return $this->join('/', 'config', $this->configFileName.'.php');
     }
 
     /** @return array<string, array<string>> */

--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Edalzell\Features\Providers;
 
+use Edalzell\Features\FeatureRegistry;
 use Edalzell\Features\Features;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
@@ -60,7 +61,11 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
 
     protected function configGroup(): string
     {
-        return '';
+        if (! $this->app->bound(FeatureRegistry::class)) {
+            return '';
+        }
+
+        return $this->app->make(FeatureRegistry::class)->get($this->name())?->configGroup ?? '';
     }
 
     protected function configPublishHandle(): string

--- a/src/Providers/FeatureServiceProvider.php
+++ b/src/Providers/FeatureServiceProvider.php
@@ -65,7 +65,11 @@ abstract class FeatureServiceProvider extends LaravelServiceProvider
             return '';
         }
 
-        return $this->app->make(FeatureRegistry::class)->get($this->name())?->configGroup ?? '';
+        if (is_null($feature = $this->app->make(FeatureRegistry::class)->get($this->name()))) {
+            return '';
+        }
+
+        return $feature->configGroup;
     }
 
     protected function configPublishHandle(): string

--- a/tests/Concerns/HasFeaturesTest.php
+++ b/tests/Concerns/HasFeaturesTest.php
@@ -24,7 +24,19 @@ it('registers features at an explicit path and namespace', function () {
     expect($registry->get('MyFeature'))
         ->name->toBe('MyFeature')
         ->rootPath->toBe('/features/path/MyFeature')
-        ->rootNamespace->toBe('My\\App\\MyFeature');
+        ->rootNamespace->toBe('My\\App\\MyFeature')
+        ->configGroup->toBe('');
+});
+
+it('stamps config group from the host composer package name', function () {
+    $app = app();
+    $registry = $app->make(FeatureRegistry::class);
+
+    (new Edalzell\Features\Tests\Fixtures\PackageHost\ServiceProvider($app))->registerFeatures();
+
+    expect($registry->get('SecureHeaders'))
+        ->configGroup->toBe('juicebox')
+        ->rootNamespace->toBe('Edalzell\\Features\\Tests\\Fixtures\\PackageHost\\Features\\SecureHeaders');
 });
 
 it('skips registration when path does not exist', function () {

--- a/tests/FeaturesTest.php
+++ b/tests/FeaturesTest.php
@@ -121,14 +121,14 @@ it('can register policies', function () {
 });
 
 it('merges config when it exists in group directory', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
     [$features, $provider] = mockFeatures();
     $features->configGroup('admin');
 
     $provider
         ->shouldReceive('mergeConfigFrom')
         ->once()
-        ->with($disk->path('config/admin/two-words.php'), 'admin.two-words');
+        ->with($disk->path('config/two-words.php'), 'admin.two-words');
 
     $features->registerConfig();
 });
@@ -143,8 +143,8 @@ it('wont merge config when group directory config does not exist', function () {
     $features->registerConfig();
 });
 
-it('publishes grouped config from the group directory', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
+it('publishes grouped config from the flat feature file', function () {
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
     [$features, $provider] = mockFeatures();
     $features->configGroup('admin');
 
@@ -152,7 +152,7 @@ it('publishes grouped config from the group directory', function () {
         ->shouldReceive('publishes')
         ->once()
         ->with(
-            [$disk->path('config/admin/two-words.php') => config_path('admin/two-words.php')],
+            [$disk->path('config/two-words.php') => config_path('admin/two-words.php')],
             'two-words-config',
         );
 

--- a/tests/Providers/FeatureServiceProviderTest.php
+++ b/tests/Providers/FeatureServiceProviderTest.php
@@ -50,14 +50,14 @@ it('merges config via register', function () {
 });
 
 it('publishes config to group directory when group is set', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
     $provider = mockServiceProvider(TestGroupedServiceProvider::class);
 
     $provider
         ->shouldReceive('publishes')
         ->once()
         ->with(
-            [$disk->path('config/admin/two-words.php') => config_path('admin/two-words.php')],
+            [$disk->path('config/two-words.php') => config_path('admin/two-words.php')],
             'admin-two-words-config'
         );
 
@@ -65,13 +65,13 @@ it('publishes config to group directory when group is set', function () {
 });
 
 it('merges config from group directory via register', function () {
-    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/admin/two-words.php', '');
+    $disk = tap(mockOnDemandDisk('features/TwoWords'))->put('config/two-words.php', '');
     $provider = mockServiceProvider(TestGroupedServiceProvider::class);
 
     $provider
         ->shouldReceive('mergeConfigFrom')
         ->once()
-        ->with($disk->path('config/admin/two-words.php'), 'admin.two-words');
+        ->with($disk->path('config/two-words.php'), 'admin.two-words');
 
     $provider->register();
 });

--- a/tests/__fixtures__/PackageHost/composer.json
+++ b/tests/__fixtures__/PackageHost/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "acme/juicebox"
+}

--- a/tests/__fixtures__/PackageHost/features/SecureHeaders/src/ServiceProvider.php
+++ b/tests/__fixtures__/PackageHost/features/SecureHeaders/src/ServiceProvider.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Edalzell\Features\Tests\Fixtures\PackageHost\Features\SecureHeaders;
+
+use Edalzell\Features\Providers\FeatureServiceProvider;
+
+class ServiceProvider extends FeatureServiceProvider {}

--- a/tests/__fixtures__/PackageHost/src/ServiceProvider.php
+++ b/tests/__fixtures__/PackageHost/src/ServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Edalzell\Features\Tests\Fixtures\PackageHost;
+
+use Edalzell\Features\Concerns\HasFeatures;
+use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
+
+class ServiceProvider extends LaravelServiceProvider
+{
+    use HasFeatures;
+
+    public function boot(): void {}
+
+    public function register(): void {}
+}


### PR DESCRIPTION
## Summary
Restores #65/#68 intent: Feature config stays at `config/{file}.php` on disk. `configGroup` only affects the merge key (`{group}.{file}`) and app publish path (`config/{group}/{file}.php`).

`configGroup` now defaults from the host Composer package short name when registering package `features/` (e.g. `transformstudios/prime` → `prime`), stamped onto each `Feature` at `registerFeatures()`. Explicit `registerFeatures($path, …)` stays ungrouped (app features). Per-Feature `configGroup()` override still works (Juicebox-style tests / tags via `configPublishHandle`).

Undoes 0.9.1’s on-disk `config/{group}/` requirement.

## Test plan
- [x] Pest: flat disk + grouped merge/publish
- [x] Pest: composer short name stamped as config group for package features
- [ ] Review before merge/release as **0.9.2**